### PR TITLE
Codemirror javascript update, load codemirror only on pages that need it

### DIFF
--- a/library/codemirror.php
+++ b/library/codemirror.php
@@ -8,10 +8,12 @@
  *
  */
 
+
+
 add_action('admin_init', 'codemirror_register', 999);
 
 function codemirror_register() {
-	
+
 	wp_register_script('codemirror', get_template_directory_uri()."/library/codemirror/lib/codemirror.js");
 	wp_register_style('codemirror', get_template_directory_uri()."/library/codemirror/lib/codemirror.css");
 	
@@ -27,7 +29,14 @@ function codemirror_register() {
 	add_action('admin_head', 'codemirror_control_js');
 }
 
-function codemirror_enqueue_scripts() {
+function codemirror_enqueue_scripts($hook) {
+
+	// Load the codemirror scripts on theme-editor.php only, plugin interference is bad.
+	// http://pippinsplugins.com/loading-scripts-correctly-in-the-wordpress-admin/
+
+	if( $hook != 'theme-editor.php' ) 
+		return;
+
 	wp_enqueue_script('codemirror');
 	wp_enqueue_style('codemirror');
 	
@@ -59,7 +68,7 @@ function codemirror_control_js() {
 			$file = "application/x-httpd-php";
 	}
 ?>
-	<script type="text/javascript">
+	<script>
 		jQuery(document).ready(function() {
 		/* hack to check if the textarea exists */
 		if (jQuery('#newcontent').length) {

--- a/library/codemirror/lib/codemirror.css
+++ b/library/codemirror/lib/codemirror.css
@@ -8,20 +8,14 @@
   overflow: hidden;
 }
 
-.CodeMirror, .CodeMirror div {
-	margin-right: 15px!important;
-}
 .CodeMirror-scroll {
-	overflow-x:auto;
-	height: 650px;
-	/*
-	 This is needed to prevent an IE[67] bug where the scrolled content
-	 is visible outside of the scrolling box.
-	*/
-	position: relative;
-	outline: none;
+  overflow: auto;
+  height: 300px;
+  /* This is needed to prevent an IE[67] bug where the scrolled content
+     is visible outside of the scrolling box. */
+  position: relative;
+  outline: none;
 }
-
 
 /* Vertical scrollbar */
 .CodeMirror-scrollbar {
@@ -86,6 +80,7 @@
   word-wrap: normal;
   line-height: inherit;
   color: inherit;
+  overflow: visible;
 }
 
 .CodeMirror-wrap pre {

--- a/library/codemirror/lib/codemirror.js
+++ b/library/codemirror/lib/codemirror.js
@@ -1,5 +1,5 @@
-// CodeMirror version 2.34
-
+// CodeMirror version 2.35
+//
 // All functions that need access to the editor's state live inside
 // the CodeMirror function. Below that, at the bottom of the file,
 // some utilities are defined.
@@ -77,7 +77,7 @@ window.CodeMirror = (function() {
     // Selection-related flags. shiftSelecting obviously tracks
     // whether the user is holding shift.
     var shiftSelecting, lastClick, lastDoubleClick, lastScrollTop = 0, draggingText,
-        overwrite = false, suppressEdits = false;
+        overwrite = false, suppressEdits = false, pasteIncoming = false;
     // Variables used by startOperation/endOperation to track what
     // happened during the operation.
     var updateInput, userSelChange, changes, textChanged, selectionChanged,
@@ -130,7 +130,7 @@ window.CodeMirror = (function() {
       connect(scroller, "drop", operation(onDrop));
     }
     connect(scroller, "paste", function(){focusInput(); fastPoll();});
-    connect(input, "paste", fastPoll);
+    connect(input, "paste", function(){pasteIncoming = true; fastPoll();});
     connect(input, "cut", operation(function(){
       if (!options.readOnly) replaceSelection("");
     }));
@@ -169,6 +169,7 @@ window.CodeMirror = (function() {
         else if (option == "lineWrapping" && oldVal != value) operation(wrappingChanged)();
         else if (option == "tabSize") updateDisplay(true);
         else if (option == "keyMap") keyMapChanged();
+        else if (option == "tabindex") input.tabIndex = value;
         if (option == "lineNumbers" || option == "gutter" || option == "firstLineNumber" ||
             option == "theme" || option == "lineNumberFormatter") {
           gutterChanged();
@@ -956,12 +957,13 @@ window.CodeMirror = (function() {
       while (same < l && prevInput[same] == text[same]) ++same;
       if (same < prevInput.length)
         sel.from = {line: sel.from.line, ch: sel.from.ch - (prevInput.length - same)};
-      else if (overwrite && posEq(sel.from, sel.to))
+      else if (overwrite && posEq(sel.from, sel.to) && !pasteIncoming)
         sel.to = {line: sel.to.line, ch: Math.min(getLine(sel.to.line).text.length, sel.to.ch + (text.length - same))};
       replaceSelection(text.slice(same), "end");
       if (text.length > 1000) { input.value = prevInput = ""; }
       else prevInput = text;
       if (!nestedOperation) endOperation();
+      pasteIncoming = false;
       return true;
     }
     function resetInput(user) {
@@ -1418,7 +1420,7 @@ window.CodeMirror = (function() {
         var startChar = line.charAt(start);
         var check = isWordChar(startChar) ? isWordChar :
                     /\s/.test(startChar) ? function(ch) {return /\s/.test(ch);} :
-                    function(ch) {return !/\s/.test(ch) && !isWordChar(ch);};
+                    function(ch) {return !/\s/.test(ch) && isWordChar(ch);};
         while (start > 0 && check(line.charAt(start - 1))) --start;
         while (end < line.length && check(line.charAt(end))) ++end;
       }
@@ -1462,6 +1464,7 @@ window.CodeMirror = (function() {
 
       if (indentString != curSpaceString)
         replaceRange(indentString, {line: n, ch: 0}, {line: n, ch: curSpaceString.length});
+      line.stateAfter = null;
     }
 
     function loadMode() {
@@ -1507,18 +1510,17 @@ window.CodeMirror = (function() {
 
     function TextMarker(type, style) { this.lines = []; this.type = type; if (style) this.style = style; }
     TextMarker.prototype.clear = operation(function() {
-      var min = Infinity, max = -Infinity;
+      var min, max;
       for (var i = 0; i < this.lines.length; ++i) {
         var line = this.lines[i];
-        var span = getMarkedSpanFor(line.markedSpans, this, true);
-        if (span.from != null || span.to != null) {
-          var lineN = lineNo(line);
-          min = Math.min(min, lineN); max = Math.max(max, lineN);
-        }
+        var span = getMarkedSpanFor(line.markedSpans, this);
+        if (span.from != null) min = lineNo(line);
+        if (span.to != null) max = lineNo(line);
+        line.markedSpans = removeMarkedSpan(line.markedSpans, span);
       }
-      if (min != Infinity)
-        changes.push({from: min, to: max + 1});
+      if (min != null) changes.push({from: min, to: max + 1});
       this.lines.length = 0;
+      this.explicitlyCleared = true;
     });
     TextMarker.prototype.find = function() {
       var from, to;
@@ -1545,7 +1547,7 @@ window.CodeMirror = (function() {
         var span = {from: curLine == from.line ? from.ch : null,
                     to: curLine == to.line ? to.ch : null,
                     marker: marker};
-        (line.markedSpans || (line.markedSpans = [])).push(span);
+        line.markedSpans = (line.markedSpans || []).concat([span]);
         marker.lines.push(line);
         ++curLine;
       });
@@ -1556,8 +1558,9 @@ window.CodeMirror = (function() {
     function setBookmark(pos) {
       pos = clipPos(pos);
       var marker = new TextMarker("bookmark"), line = getLine(pos.line);
+      history.addChange(pos.line, 1, [newHL(line.text, line.markedSpans)], true);
       var span = {from: pos.ch, to: pos.ch, marker: marker};
-      (line.markedSpans || (line.markedSpans = [])).push(span);
+      line.markedSpans = (line.markedSpans || []).concat([span]);
       marker.lines.push(line);
       return marker;
     }
@@ -1646,8 +1649,6 @@ window.CodeMirror = (function() {
 
     function measureLine(line, ch) {
       if (ch == 0) return {top: 0, left: 0};
-      var wbr = options.lineWrapping && ch < line.text.length &&
-                spanAffectsWrapping.test(line.text.slice(ch - 1, ch + 1));
       var pre = lineContent(line, ch);
       removeChildrenAndAdd(measure, pre);
       var anchor = pre.anchor;
@@ -1980,6 +1981,7 @@ window.CodeMirror = (function() {
       if (extensions.propertyIsEnumerable(ext) &&
           !instance.propertyIsEnumerable(ext))
         instance[ext] = extensions[ext];
+    for (var i = 0; i < initHooks.length; ++i) initHooks[i](instance);
     return instance;
   } // (end of function CodeMirror)
 
@@ -2076,6 +2078,9 @@ window.CodeMirror = (function() {
   CodeMirror.defineExtension = function(name, func) {
     extensions[name] = func;
   };
+
+  var initHooks = [];
+  CodeMirror.defineInitHook = function(f) {initHooks.push(f);};
 
   var modeExtensions = CodeMirror.modeExtensions = {};
   CodeMirror.extendMode = function(mode, properties) {
@@ -2206,6 +2211,7 @@ window.CodeMirror = (function() {
     var name = keyNames[e_prop(event, "keyCode")];
     return name == "Ctrl" || name == "Alt" || name == "Shift" || name == "Mod";
   }
+  CodeMirror.isModifierKey = isModifierKey;
 
   CodeMirror.fromTextArea = function(textarea, options) {
     if (!options) options = {};
@@ -2355,14 +2361,18 @@ window.CodeMirror = (function() {
     this.from = from; this.to = to; this.marker = marker;
   }
 
-  function getMarkedSpanFor(spans, marker, del) {
+  function getMarkedSpanFor(spans, marker) {
     if (spans) for (var i = 0; i < spans.length; ++i) {
       var span = spans[i];
-      if (span.marker == marker) {
-        if (del) spans.splice(i, 1);
-        return span;
-      }
+      if (span.marker == marker) return span;
     }
+  }
+
+  function removeMarkedSpan(spans, span) {
+    var r;
+    for (var i = 0; i < spans.length; ++i)
+      if (spans[i] != span) (r || (r = [])).push(spans[i]);
+    return r;
   }
 
   function markedSpansBefore(old, startCh, endCh) {
@@ -2448,7 +2458,15 @@ window.CodeMirror = (function() {
   // hl stands for history-line, a data structure that can be either a
   // string (line without markers) or a {text, markedSpans} object.
   function hlText(val) { return typeof val == "string" ? val : val.text; }
-  function hlSpans(val) { return typeof val == "string" ? null : val.markedSpans; }
+  function hlSpans(val) {
+    if (typeof val == "string") return null;
+    var spans = val.markedSpans, out = null;
+    for (var i = 0; i < spans.length; ++i) {
+      if (spans[i].marker.explicitlyCleared) { if (!out) out = spans.slice(0, i); }
+      else if (out) out.push(spans[i]);
+    }
+    return !out ? spans : out.length ? out : null;
+  }
   function newHL(text, spans) { return spans ? {text: text, markedSpans: spans} : text; }
 
   function detachMarkedSpans(line) {
@@ -2584,13 +2602,17 @@ window.CodeMirror = (function() {
         span = function(html, text, style) {
           var l = text.length;
           if (wrapAt >= outPos && wrapAt < outPos + l) {
-            if (wrapAt > outPos) {
-              span_(html, text.slice(0, wrapAt - outPos), style);
+            var cut = wrapAt - outPos;
+            if (cut) {
+              span_(html, text.slice(0, cut), style);
               // See comment at the definition of spanAffectsWrapping
-              if (compensateForWrapping) html.appendChild(elt("wbr"));
+              if (compensateForWrapping) {
+                var view = text.slice(cut - 1, cut + 1);
+                if (spanAffectsWrapping.test(view)) html.appendChild(elt("wbr"));
+                else if (!ie_lt8 && /\w\w/.test(view)) html.appendChild(document.createTextNode("\u200d"));
+              }
             }
             html.appendChild(anchor);
-            var cut = wrapAt - outPos;
             span_(anchor, opera ? text.slice(cut, cut + 1) : text.slice(cut), style);
             if (opera) span_(html, text.slice(cut + 1), style);
             wrapAt--;
@@ -2874,7 +2896,7 @@ window.CodeMirror = (function() {
       var time = +new Date, cur = lst(this.done), last = cur && lst(cur);
       var dtime = time - this.time;
 
-      if (this.compound && cur && !this.closed) {
+      if (cur && !this.closed && this.compound) {
         cur.push({start: start, added: added, old: old});
       } else if (dtime > 400 || !last || this.closed ||
                  last.start > start + old.length || last.start + last.added < start) {
@@ -3081,7 +3103,7 @@ window.CodeMirror = (function() {
     return -1;
   }
   function isWordChar(ch) {
-    return /\w/.test(ch) || ch.toUpperCase() != ch.toLowerCase();
+    return /\w/.test(ch) || ch.toUpperCase() != ch.toLowerCase() || /[\u4E00-\u9FA5]/.test(ch);
   }
 
   // See if "".split is the broken IE version, if so, provide an
@@ -3137,7 +3159,7 @@ window.CodeMirror = (function() {
     for (var i = 1; i <= 12; i++) keyNames[i + 111] = keyNames[i + 63235] = "F" + i;
   })();
 
-  CodeMirror.version = "2.34";
+  CodeMirror.version = "2.35";
 
   return CodeMirror;
 })();


### PR DESCRIPTION
This was definitely a pain to troubleshoot but I believe it was time well spent. I installed the RoyalSlider plugin which uses the codemirror javascript libs. After some digging I see the bootstrap-start-theme is loading them on every admin page. Not cool!

I think the only page this really enhances is the theme-editor.php page. If it is needed on more then is can be specified so it does not conflict with other awesome plugins.
